### PR TITLE
Update README with simpler setup steps for Heroku.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ https://enterlab-rente.herokuapp.com/
 
 To make Rente run on Heroku, you need to let Leiningen on Heroku use the "package" build task.
 
-To make this work you need to point Heroku to this build pack:
-https://github.com/heroku/heroku-buildpack-clojure
-
-To do this, and point Leiningen on Heroku to the "package" target, add the following two config variables to Heroku by running this command:
+To do this, and point Leiningen on Heroku to the "package" target, add the following config variable to Heroku by running this command:
 
 ```
-heroku config:add BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-clojure LEIN_BUILD_TASK=package
+heroku config:add LEIN_BUILD_TASK=package
 ```
 
 Everything is nicely wrapped in shiny purple foil if you simply click this button:


### PR DESCRIPTION
I think setting the `package` task could be avoided by defining the `production` profile to do the necessary tasks. I can submit a PR for this if desired.
