### PR TITLE
fixing figwheel warning

### DIFF
--- a/dev/start.cljs
+++ b/dev/start.cljs
@@ -1,4 +1,4 @@
-(ns start
+(ns rente.start
   (:require [figwheel.client :as fw]
             [rente.client.app :as app]))
 

--- a/resources-index/dev/index.html
+++ b/resources-index/dev/index.html
@@ -12,7 +12,7 @@
     <script type="text/javascript" src="js/out/goog/base.js"></script>
     <script type="text/javascript" src="js/app.js"></script>
     <script type="text/javascript">
-      goog.require("start");
+      goog.require("rente.start");
     </script>
   </body>
 </html>


### PR DESCRIPTION
changed start to rente.start in in start.cljs and index.html
