### PR TITLE
Update project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [com.cognitect/transit-clj "0.8.285"]
                  [com.cognitect/transit-cljs "0.8.239"]
 
-                 [reagent "0.6.0-RC"]
+                 [reagent "0.6.0-rc"]
                  [org.webjars/bootstrap "4.0.0-alpha"]]
 
   :plugins [[lein-cljsbuild "1.1.1"]]


### PR DESCRIPTION
change `[reagent "0.6.0-RC"]` to `[reagent "0.6.0-rc"]`.
Error message was

```
Could not find artifact reagent:reagent:jar:0.6.0-RC in central (https://repo1.maven.org/maven2/)
Could not find artifact reagent:reagent:jar:0.6.0-RC in clojars (https://clojars.org/repo/)
```
